### PR TITLE
[fix]: Вызов preventDefault для всех событий

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,9 +76,10 @@ export default {
     document.addEventListener('keydown', pKey => {
       const decodedKey = decodeKey(pKey)
       if (!availableElement(decodedKey)) return
+      const items = mapElements.get(decodedKey)
+      if (!items) return
       pKey.preventDefault()
       pKey.stopPropagation()
-      const items = mapElements.get(decodedKey)
       const item = items.at(-1)
       if (!item.focus) {
         if ((!item.once && !item.push) || (item.push && !keyPressed)) dispatchShortkeyEvent(items)
@@ -91,11 +92,12 @@ export default {
 
     document.addEventListener('keyup', pKey => {
       const decodedKey = decodeKey(pKey)
-      keyPressed = false
       if (!availableElement(decodedKey)) return
+      const items = mapElements.get(decodedKey)
+      if (!items) return
+      keyPressed = false
       pKey.preventDefault()
       pKey.stopPropagation()
-      const items = mapElements.get(decodedKey)
       const item = items.at(-1)
       if ((item.once && !item.dispatched) || item.push) dispatchShortkeyEvent(items)
     }, true)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tequila99/vue3-shortkey",
-  "version": "1.0.2",
-  "description": "A plugin for VueJS 3.x accepts shortcuts globaly and in a single listener.",
+  "version": "1.0.3",
+  "description": "A plugin for VueJS 3.x accepts shortcuts globally and in a single listener.",
   "main": "index.js",
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
- preventDefault и stopPropagation вызываются только при наличии такого клавиатурного сокращения для смонтированных элементов

Changelog: fixed